### PR TITLE
Refactor to use plenary.nvim curl wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ export OBSIDIAN_REST_API_KEY=<your api key, without the brackets>
     "BufNewFile *.md",
   },
   lazy = true,
+  dependencies = {
+    "nvim-lua/plenary.nvim",
+  }
 }
 ```
 
@@ -51,6 +54,9 @@ require('packer').startup(function()
       'oflisback/obsidian-bridge.nvim',
       requires = { "nvim-telescope/telescope.nvim" }
       config = function() require('obsidian-bridge').setup() end
+      requires = {
+        "nvim-lua/plenary.nvim",
+      },
     }
 end)
 ```
@@ -62,6 +68,7 @@ end)
 ```vim
 Plug 'nvim-telescope/telescope.nvim'
 Plug 'oflisback/obsidian-bridge.nvim'
+  Plug 'nvim-lua/plenary.nvim'
 ```
 
 </details>


### PR DESCRIPTION
This PR refactors how the network requests with curl are done to use the plenary.nvim curl wrapper. Unfortunately it depends on a currently unreleased version that includes [this commit](https://github.com/nvim-lua/plenary.nvim/commit/0c31c398261567cda89b66ddffc69d39495f63ae).

When a new release tag has been set for plenary.nvim, probably v0.1.4, this PR can be integrated.