### PR TITLE
Normalize file paths on windows

### DIFF
--- a/lua/obsidian-bridge/init.lua
+++ b/lua/obsidian-bridge/init.lua
@@ -26,6 +26,9 @@ end
 local function get_active_buffer_obsidian_markdown_filename()
 	local bufnr = vim.api.nvim_get_current_buf()
 	local filename_incl_path = vim.api.nvim_buf_get_name(bufnr)
+	if vim.fn.has("win32") then
+		filename_incl_path = string.gsub(filename_incl_path, "\\", "/")
+	end
 	if filename_incl_path == nil or string.sub(filename_incl_path, -3) ~= ".md" then
 		return nil
 	end


### PR DESCRIPTION
Hello, great plugin, thanks for making it! 
On windows, `get_active_buffer_obsidian_markdown_filename()` was inconsistent, resulting in the plugin not changing files in obsidian. From my limited investigation, I think it has something to do with [obsidian.nvim](https://github.com/epwalsh/obsidian.nvim) and its follow through function. After using the function, the path separators would change from "\\\\" to "/". I think its best to just replace all instances of the path to have separators of "/".