### PR TITLE
fix(api): correct plenary.nvim curl api calls

### DIFF
--- a/lua/obsidian-bridge/commands.lua
+++ b/lua/obsidian-bridge/commands.lua
@@ -4,7 +4,7 @@ local M = {}
 
 M.register = function(configuration, api_key)
 	function ObsidianBridgeDailyNote()
-		network.execute_command(configuration, api_key, "daily-notes")
+		network.execute_command(configuration, api_key, "POST", "daily-notes")
 		-- would be neat if it also opened daily note
 	end
 	vim.cmd("command! ObsidianBridgeDailyNote lua ObsidianBridgeDailyNote()")
@@ -14,12 +14,12 @@ M.register = function(configuration, api_key)
 	vim.cmd("command! ObsidianBridgeTelescopeCommand lua ObsidianBridgeTelescopeCommand()")
 
 	function ObsidianBridgeOpenGraph()
-		network.execute_command(configuration, api_key, "graph:open")
+		network.execute_command(configuration, api_key, "POST", "graph:open")
 	end
 	vim.cmd("command! ObsidianBridgeOpenGraph lua ObsidianBridgeOpenGraph()")
 
 	function ObsidianBridgeOpenVaultMenu()
-		network.execute_command(configuration, api_key, "app:open-vault")
+		network.execute_command(configuration, api_key, "POST", "app:open-vault")
 	end
 	vim.cmd("command! ObsidianBridgeOpenVaultMenu lua ObsidianBridgeOpenVaultMenu()")
 end

--- a/lua/obsidian-bridge/commands.lua
+++ b/lua/obsidian-bridge/commands.lua
@@ -4,7 +4,7 @@ local M = {}
 
 M.register = function(configuration, api_key)
 	function ObsidianBridgeDailyNote()
-		network.execute_command(configuration, api_key, "POST", "daily-notes")
+		network.execute_command(configuration, api_key, "daily-notes")
 		-- would be neat if it also opened daily note
 	end
 	vim.cmd("command! ObsidianBridgeDailyNote lua ObsidianBridgeDailyNote()")
@@ -14,12 +14,12 @@ M.register = function(configuration, api_key)
 	vim.cmd("command! ObsidianBridgeTelescopeCommand lua ObsidianBridgeTelescopeCommand()")
 
 	function ObsidianBridgeOpenGraph()
-		network.execute_command(configuration, api_key, "POST", "graph:open")
+		network.execute_command(configuration, api_key, "graph:open")
 	end
 	vim.cmd("command! ObsidianBridgeOpenGraph lua ObsidianBridgeOpenGraph()")
 
 	function ObsidianBridgeOpenVaultMenu()
-		network.execute_command(configuration, api_key, "POST", "app:open-vault")
+		network.execute_command(configuration, api_key, "app:open-vault")
 	end
 	vim.cmd("command! ObsidianBridgeOpenVaultMenu lua ObsidianBridgeOpenVaultMenu()")
 end

--- a/lua/obsidian-bridge/network.lua
+++ b/lua/obsidian-bridge/network.lua
@@ -59,7 +59,7 @@ M.execute_command = function(final_config, api_key, command)
 end
 
 M.telescope_command = function(final_config, api_key)
-	local commands = M.execute_command(final_config, api_key, "GET", "")
+	local commands = M.execute_command(final_config, api_key, "")
 	if commands == nil or commands.commands == nil then
 		vim.notify("Get commands list failed")
 		return
@@ -81,11 +81,11 @@ M.telescope_command = function(final_config, api_key)
 					results = command_names,
 				}),
 				sorter = telescope_conf.generic_sorter(opts),
-				attach_mappings = function(prompt_bufnr, map)
+				attach_mappings = function(prompt_bufnr, _)
 					actions.select_default:replace(function()
 						actions.close(prompt_bufnr)
 						local selection = action_state.get_selected_entry()
-						M.execute_command(final_config, api_key, "POST", command_name_id_map[selection[1]])
+						M.execute_command(final_config, api_key, command_name_id_map[selection[1]])
 					end)
 					return true
 				end,


### PR DESCRIPTION
Not the cleanest fix but this enables the proper functionality of the commands

- `ObsidianBridgeDailyNote`
- `ObsidianBridgeOpenGraph`
- `ObsidianBridgeOpenVaultMenu`
- `ObsidianBridgeTelescopeCommand`

The last one uses a `GET` request while the others use `POST` requests. Someone with more experience in web APIs might also extend this to support `PATCH`, `DELETE` etc APIs as documented [here](https://coddingtonbear.github.io/obsidian-local-rest-api/).

Earlier, the only thing working for me was updating the view on switching the buffers.

EDIT: I checked with the latest instructions and specified fork of the plugin and this PR works for the scrolling feature as well.