### PR TITLE
Make telescope.nvim optional and add fzf-lua support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ export OBSIDIAN_REST_API_KEY="your_api_key_here"
 require('packer').startup(function()
     use {
       'oflisback/obsidian-bridge.nvim',
-      requires = { "nvim-telescope/telescope.nvim" }
+      requires = { "nvim-telescope/telescope.nvim" },
+      -- requires = { "ibhagwan/fzf-lua" }, -- For picker = "fzf_lua" (see below)
       config = function() require('obsidian-bridge').setup() end
       requires = {
         "nvim-lua/plenary.nvim",
@@ -72,6 +73,8 @@ end)
 
 ```vim
 Plug 'nvim-telescope/telescope.nvim'
+" For picker = "fzf_lua" (see below)
+" Plug 'ibhagwan/fzf-lua' 
 Plug 'oflisback/obsidian-bridge.nvim'
   Plug 'nvim-lua/plenary.nvim'
 ```
@@ -89,6 +92,7 @@ local bridge_settings = {
   scroll_sync = false, -- See "Sync of buffer scrolling" section below
   cert_path = nil, -- See "SSL configuration" section below
   warnings = true, -- Show misconfiguration warnings
+  picker = "telescope", -- Picker to use with ObsidianBridgePickCommand ("telescope" | "fzf_lua")
 }
 
 -- If you are using lazy in your config,
@@ -96,6 +100,7 @@ local bridge_settings = {
 return {
   "oflisback/obsidian-bridge.nvim",
   dependencies = { "nvim-telescope/telescope.nvim" },
+  -- dependencies = { "ibhagwan/fzf-lua" }, -- For picker = "fzf_lua"
   opts = bridge_settings,
   event = {
     "BufReadPre *.md",
@@ -158,7 +163,7 @@ SSL should now be ready to use. `obsidian-bridge` will warn you about any detect
 - `:ObsidianBridgeDailyNote` takes you to your daily note or generates it for you if it doesn't already exist. Make sure to have the Daily Notes core plugin enabled in Obsidian for this to work. Since it internally uses the Daily Note plugin to create the note for you, templates will work the same way as if it was triggered from within Obsidian.
 - `:ObsidianBridgeOpenGraph` opens the graph view in Obsidian, as long as the Graph core plugin is enabled.
 - `:ObsidianBridgeOpenVaultMenu` opens the Obsidian vault selection dialog. Obsidian does not expose a way to switch to another vault programmatically (yet?).
-- `:ObsidianBridgeTelescopeCommand` lists all the executable commands in Telescope. Execute the selected one.
+- `:ObsidianBridgePickCommand` lists all the executable commands with the configured `picker`. Execute the selected one.
 - `:ObsidianBridgeOn` activate plugin.
 - `:ObsidianBridgeOff` deactivate plugin, this will prevent calls towards Obsidian.
 - `:ObsidianBridgeToggle` toggle plugin active/inactive.

--- a/lua/obsidian-bridge/commands.lua
+++ b/lua/obsidian-bridge/commands.lua
@@ -25,12 +25,12 @@ M.register = function(configuration, api_key)
 	end
 	vim.cmd("command! ObsidianBridgeDailyNote lua ObsidianBridgeDailyNote()")
 
-	function ObsidianBridgeTelescopeCommand()
+	function ObsidianBridgePickCommand()
 		execute_if_active(function()
-			network.telescope_command(configuration, api_key)
+			network.pick_command(configuration, api_key)
 		end)
 	end
-	vim.cmd("command! ObsidianBridgeTelescopeCommand lua ObsidianBridgeTelescopeCommand()")
+	vim.cmd("command! ObsidianBridgePickCommand lua ObsidianBridgePickCommand()")
 
 	function ObsidianBridgeOpenGraph()
 		execute_if_active(function()

--- a/lua/obsidian-bridge/config.lua
+++ b/lua/obsidian-bridge/config.lua
@@ -69,6 +69,13 @@ local function check_for_ssl_errors(final)
 	end
 end
 
+local function check_picker(final)
+	local network = require("obsidian-bridge.network")
+	if not network.pickers[final.picker] then
+		vim.notify('Invalid picker: "' .. final.picker .. '"', vim.log.levels.ERROR)
+	end
+end
+
 M.create_final_config = function(user_config)
 	local default_config = {
 		obsidian_server_address = "http://localhost:27123",
@@ -90,12 +97,14 @@ M.create_final_config = function(user_config)
 	final.cert_path = normalize_certpath(final.cert_path)
 	-- check for misconfigurations, warn the user if found
 	check_for_ssl_errors(final)
+	-- check for the selected picker
 	check_url(final)
 	-- empty table if cert_path == nil
 	-- extendable, other curl args can go here
 	final.raw_args = construct_raw_args({
 		["--cacert"] = final.cert_path,
 	})
+	check_picker(final)
 	M.final_config = final
 end
 

--- a/lua/obsidian-bridge/config.lua
+++ b/lua/obsidian-bridge/config.lua
@@ -77,6 +77,7 @@ M.create_final_config = function(user_config)
 		cert_path = nil,
 		-- Show configuration warnings
 		warnings = true,
+		picker = "telescope",
 	}
 	local final = vim.tbl_extend("keep", user_config or {}, default_config)
 	-- Set warning suppression if requested by the user


### PR DESCRIPTION
I think a relevant portion of Neovim users (including me) use some other picker like [fzf-lua](https://github.com/ibhagwan/fzf-lua) instead of telescope, and it'd be nice if this plugin supported it for `ObsidianBridgeTelescopeCommand`. This PR adds a `picker` config option, which has a default value of `"telescope"` and can be set to `"fzf_lua"` in order for the command palette picker to use fzf-lua. Since the command isn't all about telescope anymore, I've renamed it to `ObsidianBridgePickCommand` (could be changed, though. Dunno).

Also, since it might be possible to implement other pickers like [mini.pick](https://github.com/echasnovski/mini.pick), I've added a simple interface to add new command pickers through a table at `require('obsidian-bridge.network').pickers`. Maybe the location of this pickers table could be moved outside `network`, though. Not sure how you'd want to organize it.

Awesome plugin btw! Thanks a lot for the effort, I have no idea what I would do without the scroll sync thingy.