### PR TITLE
Make get_vault_name work in windows.

### DIFF
--- a/lua/obsidian-bridge/event_handlers.lua
+++ b/lua/obsidian-bridge/event_handlers.lua
@@ -25,7 +25,7 @@ local function get_active_buffer_obsidian_markdown_filename()
 		filename_incl_path = string.gsub(filename_incl_path, "\\", "/")
 	end
 
-	local path = vim.fn.fnamemodify(filename_incl_path, ":p:h")
+	local path = vim.fn.fnamemodify(filename_incl_path, ":p")
 	local vault_name = get_vault_name(path)
 	if not vault_name then
 		return nil

--- a/lua/obsidian-bridge/event_handlers.lua
+++ b/lua/obsidian-bridge/event_handlers.lua
@@ -5,13 +5,11 @@ local M = {}
 
 local function get_vault_name(path)
 	local current_path = vim.fn.expand(path)
-	while current_path ~= "/" do
-		local obsidian_folder = current_path .. "/.obsidian"
+	for dir in vim.fs.parents(current_path) do
+		local obsidian_folder = vim.fs.joinpath(dir, ".obsidian")
 		if vim.fn.isdirectory(obsidian_folder) == 1 then
-			local vault_name = obsidian_folder:match("/([^/]+)/%.obsidian$")
-			return vault_name:gsub("([^%w])", "%%%1")
+			return vim.fs.basename(dir)
 		end
-		current_path = vim.fn.fnamemodify(current_path, ":h")
 	end
 	return false
 end


### PR DESCRIPTION
Fix first comment of #23 .

I tested on Windows 11 and WSL2 (Ubuntu) under the following conditions.

* neovim v0.11.1
* Obsidian 1.8.10
* BRAT 1.1.4
* [oflisback/obsidian-local-rest-api](https://github.com/oflisback/obsidian-local-rest-api) v1.0.0

I used API that added in v0.10.0 so this PR requires neovim v0.10.0+.

