### PR TITLE
feat: add default formatting 

### DIFF
--- a/.nvim.lua
+++ b/.nvim.lua
@@ -1,0 +1,4 @@
+vim.o.tabstop = 4
+vim.o.expandtab = false
+vim.o.softtabstop = 4
+vim.o.shiftwidth = 4

--- a/lua/obsidian-bridge/commands.lua
+++ b/lua/obsidian-bridge/commands.lua
@@ -23,6 +23,7 @@ M.register = function(configuration, api_key)
 		end)
 		-- would be neat if it also opened daily note
 	end
+
 	vim.cmd("command! ObsidianBridgeDailyNote lua ObsidianBridgeDailyNote()")
 
 	function ObsidianBridgePickCommand()
@@ -30,6 +31,7 @@ M.register = function(configuration, api_key)
 			network.pick_command(configuration, api_key)
 		end)
 	end
+
 	vim.cmd("command! ObsidianBridgePickCommand lua ObsidianBridgePickCommand()")
 
 	function ObsidianBridgeOpenGraph()
@@ -37,6 +39,7 @@ M.register = function(configuration, api_key)
 			network.execute_command(configuration, api_key, "POST", "graph:open")
 		end)
 	end
+
 	vim.cmd("command! ObsidianBridgeOpenGraph lua ObsidianBridgeOpenGraph()")
 
 	function ObsidianBridgeOpenVaultMenu()
@@ -44,6 +47,7 @@ M.register = function(configuration, api_key)
 			network.execute_command(configuration, api_key, "POST", "app:open-vault")
 		end)
 	end
+
 	vim.cmd("command! ObsidianBridgeOpenVaultMenu lua ObsidianBridgeOpenVaultMenu()")
 
 	function ObsidianBridgeOn()
@@ -53,6 +57,7 @@ M.register = function(configuration, api_key)
 			event_handlers.on_buf_enter()
 		end
 	end
+
 	vim.cmd("command! ObsidianBridgeOn lua ObsidianBridgeOn()")
 
 	function ObsidianBridgeOff()
@@ -61,6 +66,7 @@ M.register = function(configuration, api_key)
 			config.on = false
 		end
 	end
+
 	vim.cmd("command! ObsidianBridgeOff lua ObsidianBridgeOff()")
 
 	function ObsidianBridgeToggle()
@@ -70,6 +76,7 @@ M.register = function(configuration, api_key)
 			ObsidianBridgeOn()
 		end
 	end
+
 	vim.cmd("command! ObsidianBridgeToggle lua ObsidianBridgeToggle()")
 end
 

--- a/lua/obsidian-bridge/config.lua
+++ b/lua/obsidian-bridge/config.lua
@@ -113,9 +113,9 @@ M.get_api_key = function()
 	if api_key == nil then
 		vim.notify(
 			M.api_key_env_var_name
-				.. " environment variable is not set. Please set "
-				.. M.api_key_env_var_name
-				.. " in your shell configuration.",
+			.. " environment variable is not set. Please set "
+			.. M.api_key_env_var_name
+			.. " in your shell configuration.",
 			vim.log.levels.ERROR
 		)
 	end


### PR DESCRIPTION
MR created as part of #38 This should be merged first before #39 .

Implementation:
- should use`lua_ls` as formatter which respects [vim's spacing setting](https://github.com/chardskarth/obsidian-bridge.nvim/blob/590ea77e84f9219e4f328dd0911a3afda1e3f906/.nvim.lua)
- should use [`nvim-config-lua`](https://github.com/klen/nvim-config-local) to read `.nvim.lua` which contains spacing settings.

