### PR TITLE
fix: normalize NFD filenames to NFC before sending

### DIFF
--- a/lua/obsidian-bridge/network.lua
+++ b/lua/obsidian-bridge/network.lua
@@ -167,7 +167,7 @@ M.execute_command_by_name = function(final_config, api_key, command_name)
 end
 
 M.open_in_obsidian = function(filename, final_config, api_key)
-	local path = utils.EncodeURI("/open/" .. filename)
+	local path = utils.EncodeURI("/open/" .. utils.normalize_filename_for_mac(filename))
 	make_api_call(final_config, api_key, "POST", path)
 end
 

--- a/lua/obsidian-bridge/utils.lua
+++ b/lua/obsidian-bridge/utils.lua
@@ -88,4 +88,13 @@ M.getVaultName = function(path)
 	return false
 end
 
+-- Normalize macOS NFD filenames to NFC before sending to Obsidian REST API.
+-- macOS returns filenames in NFD (decomposed) form, which causes Obsidian's
+-- REST API to fail to match against its NFC-indexed paths. Uses vim.fn.iconv
+-- with macOS-specific "utf-8-mac" encoding.
+-- On non-macOS platforms, returns the string as-is.
+M.normalize_filename_for_mac = function(str)
+	return vim.fn.has("mac") == 1 and vim.fn.iconv(str, "utf-8-mac", "utf-8") or str
+end
+
 return M


### PR DESCRIPTION
macOS returns filenames in Unicode NFD (decomposed) form. When these NFD paths are sent to Obsidian's REST API, openLinkText fails to match against Obsidian's NFC-indexed paths, causing duplicate files to be created.

Add normalize_filename_for_mac() using vim.fn.iconv with macOS-specific "utf-8-mac" encoding to convert filenames to NFC before URL-encoding. On non-macOS platforms, the string is returned as-is.